### PR TITLE
Remove py.typed

### DIFF
--- a/apiclient-stubs/py.typed
+++ b/apiclient-stubs/py.typed
@@ -1,1 +1,0 @@
-partial

--- a/googleapiclient-stubs/py.typed
+++ b/googleapiclient-stubs/py.typed
@@ -1,1 +1,0 @@
-partial


### PR DESCRIPTION
They seem to be causing issues in Pyright where anything under `_apis` isn't found.