### PR TITLE
Make types-httplib2 a non-dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,13 @@ classifiers = [
 python = "^3.7"
 google-api-python-client = ">=2.107.0"
 typing-extensions = ">=3.10.0"
+types-httplib2 = ">=0.22.0.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = {version = "^1.7.0", python = "^3.8"}
 black = {version = "^23.11.0", python = "^3.8"}
 isort = {version = "^5.12.0", python = "^3.8"}
 stubdefaulter = "^0.1.0"
-types-httplib2 = ">=0.22.0.2"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This was accidentally added as a dev dependency.